### PR TITLE
Add support for custom DISTRIBUTION metric

### DIFF
--- a/lib/statix.ex
+++ b/lib/statix.ex
@@ -226,6 +226,24 @@ defmodule Statix do
   @callback timing(key, value :: String.Chars.t(), options) :: on_send
 
   @doc """
+  Same as `distribution(key, value, [])`.
+  """
+  @callback distribution(key, value :: String.Chars.t()) :: on_send
+
+  @doc """
+  Writes the given `value` to the StatsD distribution identified by `key`.
+
+  `value` is expected in milliseconds.
+
+  ## Examples
+
+      iex> MyApp.Statix.distribution("rendering", 12, [])
+      :ok
+
+  """
+  @callback distribution(key, value :: String.Chars.t(), options) :: on_send
+
+  @doc """
   Writes the given `value` to the StatsD set identified by `key`.
 
   ## Examples
@@ -348,6 +366,10 @@ defmodule Statix do
         log_if_enabled(fn -> Statix.transmit(current_statix(), :timing, key, val, options) end)
       end
 
+      def distribution(key, val, options \\ []) do
+        log_if_enabled(fn -> Statix.transmit(current_statix(), :distribution, key, val, options) end)
+      end
+
       def measure(key, options \\ [], fun) when is_function(fun, 0) do
         if Statix.enabled?(__MODULE__) do
           {elapsed, result} = :timer.tc(fun)
@@ -379,7 +401,8 @@ defmodule Statix do
         histogram: 3,
         timing: 3,
         measure: 3,
-        set: 3
+        set: 3,
+        distribution: 3
       )
     end
   end

--- a/lib/statix/packet.ex
+++ b/lib/statix/packet.ex
@@ -38,7 +38,8 @@ defmodule Statix.Packet do
     gauge: "g",
     histogram: "h",
     timing: "ms",
-    set: "s"
+    set: "s",
+    distribution: "d"
   }
 
   for {name, type} <- metrics do

--- a/test/statix/overriding_test.exs
+++ b/test/statix/overriding_test.exs
@@ -35,6 +35,10 @@ defmodule Statix.OverridingTest do
     super([key, "-overridden"], value, options)
   end
 
+  def distribution(key, value, options) do
+    super([key, "-overridden"], value, options)
+  end
+
   setup do
     connect()
   end
@@ -62,6 +66,11 @@ defmodule Statix.OverridingTest do
   test "timing/3" do
     timing("sample", 3, tags: ["foo"])
     assert_receive {:test_server, _, "sample-overridden:3|ms|#foo"}
+  end
+
+  test "distribution/3" do
+    distribution("sample", 3, tags: ["foo"])
+    assert_receive {:test_server, _, "sample-overridden:3|d|#foo"}
   end
 
   test "measure/3" do

--- a/test/statix/pool_test.exs
+++ b/test/statix/pool_test.exs
@@ -18,7 +18,8 @@ defmodule Statix.PoolingTest do
         {:histogram, [3]},
         {:timing, [3]},
         {:measure, [fn -> nil end]},
-        {:set, [3]}
+        {:set, [3]},
+        {:distribution, [3]}
       ]
       |> Enum.map(fn {function, arguments} ->
         apply(__MODULE__, function, ["sample" | arguments])


### PR DESCRIPTION
Enable DataDog [distribution metric](https://docs.datadoghq.com/metrics/distributions/)

This PR is copied from https://github.com/lexmag/statix/pull/54 but based on `feature/switch_from_config` branch

This feature unlock the possibility to have more specific metrics with percentiles calculations

:warning: I think we need to think how to maintain this feature incrementing on Statix fork. I don't think we really wanna merge this PR on `feature/switch_from_config` branch :warning: 

![test_distribution](https://user-images.githubusercontent.com/12764418/190658751-058e30e4-6c67-4b20-901b-1473bbbd7791.png)

The usage is the same of `timing` metrics

```
MyApp.Datadog.distribution(
          "my.metric.name",
          "123456789",
          tags: [ ]
        )
```

When the metric is displayed on DataDog we need to enable percentiles on Mentrics summary

![metric_summary](https://user-images.githubusercontent.com/12764418/190667883-fb895f49-812d-457e-9be6-919d52260bdc.png)
